### PR TITLE
feat: Redirect achecker.ca to primary domain

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,6 +4,7 @@ https://www.idrc.ocadu.ca/*                                                     
 https://unpopular.ca/*                                                                  https://idrc.ocadu.ca/:splat                                            301!
 https://in-kind.ca/*                                                                    https://idrc.ocadu.ca/:splat                                            301!
 https://includenet.ca/*                                                                 https://idrc.ocadu.ca/:splat                                            301!
+https://achecker.ca/*                                                                   https://idrc.ocadu.ca/:splat                                            301!
 https://websavvy.idrc.ocadu.ca/*                                                        /consulting                                                             301!
 https://websavvy.idrc.ocad.ca/*                                                         /consulting                                                             301!
 /about-the-idrc                                                                         /about                                                                  301


### PR DESCRIPTION
* [x] This pull request has been tested by running `npm run test` without errors
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

achecker.ca was added a domain alias but it's not redirecting to the primary domain (default netlify behavior). This is fine but achecker.ca is showing in Google Search results for some people with the IDRC content, which is confusing.
